### PR TITLE
fix(admin): prevent button labels from wrapping on mobile

### DIFF
--- a/app/(admin)/admin/members/accept/accept-form.tsx
+++ b/app/(admin)/admin/members/accept/accept-form.tsx
@@ -63,8 +63,12 @@ export default function AcceptForm({ userId }: { userId: string }) {
   const [role, setRole] = useState('member')
 
   return (
-    <DataForm action={acceptMemberAction} className={'flex items-center gap-2'}>
-      <div className={'text-lg font-semibold'}>{t('role')}</div>
+    // 모바일에서는 버튼이 쪼그라들지 않고 줄로 넘어가야 합니다.
+    <DataForm
+      action={acceptMemberAction}
+      className={'flex flex-wrap items-center gap-2'}
+    >
+      <span className={'admin-field-label'}>{t('role')}</span>
       <RoleButton role={role} setRole={setRole} value={'member'}>
         {t('roleMember')}
       </RoleButton>
@@ -89,11 +93,7 @@ export default function AcceptForm({ userId }: { userId: string }) {
         value={userId}
         name={'userId'}
       />
-      <SubmitButton
-        className={
-          'hover:bg-canvas flex items-center gap-2 rounded-lg border-2 p-1 px-3 font-semibold transition-colors'
-        }
-      />
+      <SubmitButton className={'admin-btn-secondary min-h-9 px-3'} />
     </DataForm>
   )
 }

--- a/app/(admin)/admin/members/accept/page.tsx
+++ b/app/(admin)/admin/members/accept/page.tsx
@@ -1,6 +1,6 @@
 import AdminDefaultLayout from '@/app/components/admin/admin-default-layout'
-import AdminNavigationButton from '@/app/components/admin/admin-navigation-button'
-import { ChevronLeftIcon } from '@heroicons/react/24/outline'
+import AdminPageHeader from '@/app/components/admin/page-header'
+import AdminEmptyState from '@/app/components/admin/empty-state'
 import db from '@/db'
 import { eq } from 'drizzle-orm'
 import { users } from '@/db/schema/users'
@@ -35,33 +35,36 @@ export default async function AcceptMemberPage() {
 
   return (
     <AdminDefaultLayout>
-      <AdminNavigationButton href={'/admin/members'}>
-        <ChevronLeftIcon className={'size-8'} />
-        <p className={'text-lg'}>{t.members}</p>
-      </AdminNavigationButton>
-      <div className={'admin-title'}>{t.approveMember}</div>
-      <div className={'flex w-full flex-col gap-2 py-4'}>
+      <AdminPageHeader
+        title={t.approveMember}
+        backHref={'/admin/members'}
+        backLabel={t.members}
+      />
+      <div className={'flex w-full flex-col gap-2'}>
         {unacceptedMembers.length === 0 && (
-          <div className={'text-ink mx-auto text-xl'}>{t.noUsersToApprove}</div>
+          <AdminEmptyState title={t.noUsersToApprove} />
         )}
         {unacceptedMembers.map((member) => (
           <div
             key={member.id}
             className={
-              'bg-surface flex items-center justify-between gap-2 rounded-lg p-2 not-md:flex-col not-md:items-start'
+              'border-hairline bg-surface flex flex-col gap-3 rounded-lg border p-3 lg:flex-row lg:items-center lg:justify-between'
             }
           >
-            <div className={'flex items-center gap-2'}>
+            <div className={'flex min-w-0 items-center gap-2.5'}>
               <Image
                 src={member.image ? member.image : '/default-user-profile.png'}
-                alt={'Profile Image'}
+                alt={''}
                 width={100}
                 height={100}
-                className={'size-12 rounded-lg object-cover'}
+                className={'size-10 shrink-0 rounded-lg object-cover'}
               />
-              <div>{member.name}</div>
+              <div className={'type-body-sm text-ink truncate font-semibold'}>
+                {member.name}
+              </div>
             </div>
-            <div className={'flex items-center gap-2'}>
+            {/* 좁은 화면에서 버튼이 압축되어 라벨이 줄바꿈되지 않도록 감쌉니다. */}
+            <div className={'flex flex-wrap items-center gap-2'}>
               <AcceptForm userId={member.id} />
               <DeleteForm userId={member.id} />
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,7 +295,9 @@
 /* ───────────── Buttons ─────────────
    DESIGN.md: 마케팅용 pill이 아니라 유틸리티 버튼의 8px 반경을 씁니다. */
 @utility admin-btn {
-  @apply type-body-sm inline-flex min-h-10 cursor-pointer items-center justify-center gap-1.5 rounded-md px-4 py-2 font-medium;
+  /* 버튼 라벨은 줄바꿈되면 안 됩니다. 좁은 화면에서는 버튼이 쪼그라드는 대신
+     부모가 `flex-wrap`으로 줄을 바꿔야 합니다. */
+  @apply type-body-sm inline-flex min-h-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md px-4 py-2 font-medium whitespace-nowrap;
   @apply transition-[background-color,border-color,color,box-shadow,transform] duration-150;
   @apply disabled:cursor-not-allowed disabled:opacity-60;
 


### PR DESCRIPTION
브랜치 정리 작업의 일부로, \`dev\` 브랜치에 남아 있던 미병합 커밋 1건을 main으로 반영합니다.

- 5a7c858 fix(admin): prevent button labels from wrapping on mobile

병합 후 \`dev\` 브랜치는 삭제됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)